### PR TITLE
Print types reasonably nicely.

### DIFF
--- a/Evaluator.hs
+++ b/Evaluator.hs
@@ -1,29 +1,30 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Evaluator where
 
+import qualified Data.Char             as Char
 import qualified Data.ByteString.Char8 as BSC
-import qualified Data.ByteString as BS
-import qualified Elm.Internal.Paths as Elm
-import qualified Environment as Env
-import qualified Data.Map as Map
-import Data.List
+import qualified Data.ByteString       as BS
+import qualified Elm.Internal.Paths    as Elm
+import qualified Environment           as Env
+import qualified Data.Map              as Map
 
-import System.IO
-import System.IO.Error  (isDoesNotExistError)
-import System.Directory (removeFile)
-import System.Exit      (ExitCode(..))
-import System.FilePath  ((</>), replaceExtension)
-import System.Process
+import Control.Applicative ((<$>), (<*>))
 import Control.Exception
-import Control.Monad (unless)
+import Control.Monad       (unless)
+import System.Directory    (removeFile)
+import System.Exit         (ExitCode(..))
+import System.FilePath     ((</>), replaceExtension)
+import System.IO
+import System.IO.Error     (isDoesNotExistError)
+import System.Process
 
 runRepl :: String -> Env.Repl -> IO Env.Repl
 runRepl "" env = return env
 runRepl input oldEnv =
   do writeFile tempElm $ Env.toElm newEnv
-     success <- run (Env.compilerPath newEnv) elmArgs $ \types -> do
+     success <- runCmdWithCallback (Env.compilerPath newEnv) elmArgs $ \types -> do
        reformatJS input tempJS
-       run "node" nodeArgs $ \value' ->
+       runCmdWithCallback "node" nodeArgs $ \value' ->
            let value = BSC.init value'
                tipe = scrapeOutputType types
                isTooLong = BSC.isInfixOf "\n" value ||
@@ -42,27 +43,26 @@ runRepl input oldEnv =
     
     nodeArgs = [tempJS]
     elmArgs  = (getSrcs newEnv) ++ ["--make", "--only-js", "--print-types", tempElm]
-    
-    run name args nextComputation =
-      do (_, stdout, stderr, handle') <-
-             createProcess (proc name args) { std_out = CreatePipe
-                                            , std_err = CreatePipe}
-         exitCode <- waitForProcess handle'
-         case (exitCode, stdout, stderr) of
-           (ExitSuccess, Just out, Just _) ->
-               nextComputation =<< BS.hGetContents out
-           (ExitFailure 127, Just _, Just _) -> failure missingExe
-           (ExitFailure _, Just out, Just err) -> do e <- BSC.hGetContents err
-                                                     o <- BSC.hGetContents out
-                                                     failure (BS.concat [o,e])
-           (_, _, _) -> failure "Unknown error!"
-      where
-        failure message = BSC.hPutStrLn stderr message >> return False
-        missingExe = BSC.pack $ unlines $
-                     [ "Error: '" ++ name ++ "' command not found."
-                     , "  Do you have it installed?"
-                     , "  Can it be run from anywhere? I.e. is it on your PATH?" ]
 
+runCmdWithCallback :: FilePath -> [String] -> (BS.ByteString -> IO Bool) -> IO Bool
+runCmdWithCallback name args callback = do
+  (_, stdout, stderr, handle') <- createProcess (proc name args) { std_out = CreatePipe
+                                                                 , std_err = CreatePipe}
+  exitCode <- waitForProcess handle'
+  case (exitCode, stdout, stderr) of
+    (ExitSuccess, Just out, Just _) ->
+       callback =<< BS.hGetContents out
+    (ExitFailure 127, Just _, Just _) -> failure missingExe
+    (ExitFailure _, Just out, Just err) -> do
+      e <- BSC.hGetContents err
+      o <- BSC.hGetContents out
+      failure (BS.concat [o,e])
+    (_, _, _) -> failure "Unknown error!"
+ where failure message = BSC.hPutStrLn stderr message >> return False
+       missingExe = BSC.pack $ unlines $
+                    [ "Error: '" ++ name ++ "' command not found."
+                    , "  Do you have it installed?"
+                    , "  Can it be run from anywhere? I.e. is it on your PATH?" ]
 
 reformatJS :: String -> String -> IO ()
 reformatJS input tempJS =
@@ -83,13 +83,12 @@ reformatJS input tempJS =
           , "  console.log(context.Native.Show.values.show(repl.", Env.output, "));" ]
 
 scrapeOutputType :: BS.ByteString -> BS.ByteString
-scrapeOutputType types
-    | name == Env.output = tipe
-    | BS.null rest       = ""
-    | otherwise          = scrapeOutputType rest
-    where
-      (next,rest) = freshLine types
-      (name,tipe) = BSC.splitAt (BSC.length Env.output) next
+scrapeOutputType = dropName . squashSpace . takeType . dropWhile (not . isOut) . BSC.lines
+  where isOut    = BS.isPrefixOf Env.output
+        dropName = BS.drop $ BSC.length Env.output
+        takeType (n:rest) = n : takeWhile isMoreType rest
+        isMoreType = (&&) <$> not . BS.null <*> (Char.isSpace . BSC.head)
+        squashSpace = BSC.unwords . BSC.words . BSC.unwords
 
 freshLine :: BS.ByteString -> (BS.ByteString, BS.ByteString)
 freshLine str | BS.null rest' = (line,"")


### PR DESCRIPTION
Implementation assumes that there will be a line that prints the type
of the current value. It then assumes that if a type annotation takes
more than one line then each line after the first will start with
spaces and the next line will not.

Should probably use the built-in parser/printer in the future.

Also some minor style tweaks.
