### PR TITLE
Parse RemoveFlag commands correctly.

### DIFF
--- a/Repl.hs
+++ b/Repl.hs
@@ -2,6 +2,7 @@ module Main where
 
 import Control.Monad
 import Control.Monad.Trans
+import Data.Functor ((<$>), (<$))
 import qualified Data.Map as Map
 import qualified Data.List as List
 import System.Console.Haskeline
@@ -125,22 +126,22 @@ flags :: Parsec String () Command
 flags = do
   string "flags"
   many space
-  choice [ do string "add" >> many1 space >> srcDir
-         , do string "remove" >> many1 space
-              n <- many1 digit
-              return $ RemoveFlag (read n)
-         , do string "list"
-              return ListFlags
-         , do string "clear"
-              return ClearFlags
+  choice [ srcDirFlag "add"    AddFlag
+         , srcDirFlag "remove" RemoveFlag
+         , ListFlags  <$ string "list"
+         , ClearFlags <$ string "clear"
          , return InfoFlags
          ]
+    where srcDirFlag name ctor = do
+            string name
+            many1 space
+            ctor <$> srcDir
 
-srcDir :: Parsec String () Command
+srcDir :: Parsec String () String
 srcDir = do
   string "--src-dir="
   dir <- manyTill anyChar (choice [ space >> return (), eof ])
-  return $ AddFlag $ "--src-dir=" ++ dir
+  return $ "--src-dir=" ++ dir
 
 flagsInfo :: String
 flagsInfo = "Usage: flags [operation]\n\


### PR DESCRIPTION
Before this commit:
`> :flags remove 1`
will crash the repl with
`elm-repl: Prelude.read: No Parse`

Looking at the code history it looks like at one point "ResetFlag" took a number and now it takes a `String` but the parsing code didn't break because it uses `read` so there was no type error. The dangers of `read`!
