### PR TITLE
Update for GHC 7.10

### DIFF
--- a/src/Eval/Meta.hs
+++ b/src/Eval/Meta.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 module Eval.Meta (eval) where
 
 import Control.Monad.State (get, modify)
@@ -79,7 +80,7 @@ flagsInfo =
     \    add --src-dir=FILEPATH\tAdd a compiler flag\n\
     \    remove --src-dir=FILEPATH\tRemove a compiler flag\n\
     \    list\t\t\tList all flags that have been added\n\
-    \    clear\t\t\tClears all flags\n" 
+    \    clear\t\t\tClears all flags\n"
 
 helpInfo :: String
 helpInfo =


### PR DESCRIPTION
This makes `elm-repl` compile without errors for me on GHC 7.10.1.

See the [release notes](https://downloads.haskell.org/~ghc/7.10.1/docs/html/users_guide/release-7-10-1.html) and [migration guide](https://ghc.haskell.org/trac/ghc/wiki/Migration/7.10) for more information about these changes.