### PR TITLE
Use ExceptT instead of (deprecated) ErrorT

### DIFF
--- a/elm-repl.cabal
+++ b/elm-repl.cabal
@@ -64,7 +64,7 @@ Executable elm-repl
     elm-package,
     filepath >= 1 && < 2,
     haskeline >= 0.7 && < 0.8,
-    mtl >= 2 && < 3,
+    mtl >= 2.2.1 && < 3,
     parsec >= 3.1.1 && < 3.5,
     process >= 1 && < 2
 

--- a/src/Eval/Code.hs
+++ b/src/Eval/Code.hs
@@ -2,7 +2,8 @@
 module Eval.Code (eval) where
 
 import Control.Monad.Cont (ContT(ContT, runContT))
-import Control.Monad.Error (ErrorT, runErrorT, throwError)
+import Control.Monad.Except (ExceptT, runExceptT)
+import Control.Monad.Error.Class (throwError)
 import Control.Monad.RWS (get, modify)
 import Control.Monad.Trans (liftIO)
 import qualified Data.Binary as Binary
@@ -115,13 +116,13 @@ nodeRunner =
 
 getType :: IO String
 getType =
-  do  result <- runErrorT getTypeHelp
+  do  result <- runExceptT getTypeHelp
       case result of
         Right tipe -> return tipe
         Left _ -> return ""
 
 
-getTypeHelp :: ErrorT String IO String
+getTypeHelp :: ExceptT String IO String
 getTypeHelp =
   do  description <- Desc.read Path.description
       binary <- liftIO (BS.readFile (interfacePath description))


### PR DESCRIPTION
The ErrorT monad transformer is [deprecated](http://hackage.haskell.org/package/mtl-2.2.1/docs/Control-Monad-Error.html).