### PR TITLE
Update repo name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: haskell
 install:
-  - git clone https://github.com/elm-lang/Elm.git
+  - git clone https://github.com/elm-lang/elm-compiler.git
   - cabal sandbox init
-  - cabal sandbox add-source Elm
+  - cabal sandbox add-source elm-compiler
   - cabal install --only-dependencies --enable-tests
 script: cabal test


### PR DESCRIPTION
I'm not even sure this file is still relevant. But if it is, it's probably better to have it point to the current repo name of elm-compiler, rather than relying on GitHub redirecting.