### PR TITLE
Point to appropriate node.js download page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This tool lets you interact with values and functions directly.
 ### Install
 
 Install [Elm Platform][platform] to get `elm-repl`. Then make sure you have
-[node.js](http://nodejs.org/download/) installed because it is needed to
+[node.js](https://nodejs.org/en/download/) installed because it is needed to
 evaluate the generated JS.
 
 [platform]: https://github.com/elm-lang/elm-platform#elm-platform


### PR DESCRIPTION
This is what was previously pointed to: http://nodejs.org/download/. See how it is not really a good target page to point to. I've replaced it by: https://nodejs.org/en/download/.