### PR TITLE
Make Travis badge reflect master branch status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Elm REPL [![Build Status](https://travis-ci.org/elm-lang/elm-repl.png)](https://travis-ci.org/elm-lang/elm-repl)
+## Elm REPL [![Build Status](https://travis-ci.org/elm-lang/elm-repl.svg?branch=master)](https://travis-ci.org/elm-lang/elm-repl)
 
 This tool lets you interact with values and functions directly.
 


### PR DESCRIPTION
Without a branch specifier, the Travis build status badge at the top of the README show the status of the latest build, which is not very useful and may give a wrong impression of brokenness (even though, as a matter of fact, `master` has a broken build in this repo right now).

(PR requested by @jvoigtlaender in https://github.com/elm-lang/core/pull/515) 