### PR TITLE
Added metacommand `:list`

### DIFF
--- a/src/Completion.hs
+++ b/src/Completion.hs
@@ -17,14 +17,9 @@ complete =
 lookupCompletions :: String -> Env.Task [Completion]
 lookupCompletions string =
     do  env <- get
-        let defs = adjustDefs (Env.defs env)
+        let defs = Trie.unionL cmds $ Env.actualDefs env
         return (completions string defs)
     where
-      adjustDefs defs =
-          Trie.unionL cmds $
-          Trie.delete Env.firstVar $
-          Trie.delete Env.lastVar defs
-
       cmds =
           Trie.fromList
               [ (":exit", "")

--- a/src/Environment.hs
+++ b/src/Environment.hs
@@ -44,6 +44,7 @@ data Config
     | Help (Maybe String)
     | Exit
     | Reset
+    | List
     deriving (Show, Eq)
 
 
@@ -66,6 +67,10 @@ needsPrint maybeDefName =
     Just _ ->
       False
 
+getName :: DefName -> String
+getName (DataDef s) = s
+getName (Import s) = s
+getName (VarDef s) = s
 
 
 -- ENVIRONMENT
@@ -81,6 +86,10 @@ data Env = Env
     }
     deriving Show
 
+
+actualDefs :: Env -> Trie String
+actualDefs env = Trie.delete firstVar $
+          Trie.delete lastVar (defs env)
 
 empty :: FilePath -> FilePath -> Env
 empty compiler interpreter =

--- a/src/Eval/Meta.hs
+++ b/src/Eval/Meta.hs
@@ -4,9 +4,12 @@ module Eval.Meta (eval) where
 import Control.Monad.State (get, modify)
 import Control.Monad.Trans (liftIO)
 import qualified Data.List as List
+import Data.Maybe
+import qualified Data.Trie as Trie
 import System.Exit (ExitCode(ExitSuccess))
 
 import qualified Environment as Env
+import Read (extractDefName)
 
 
 eval :: Env.Config -> Env.Task (Maybe ExitCode)
@@ -18,6 +21,10 @@ eval config =
     Env.Help m ->
         do displayErr "Bad command\n" m
            display helpInfo
+
+    Env.List ->
+        do  env <- get
+            display $ unlines $ map Env.getName $ concatMap (maybeToList . extractDefName) $ Trie.elems $ Env.actualDefs env
 
     Env.InfoFlags m ->
         do displayErr "Bad flag\n" m
@@ -89,4 +96,5 @@ helpInfo =
     \  :help\t\t\tList available commands\n\
     \  :flags\t\tManipulate flags sent to elm compiler\n\
     \  :reset\t\tClears all previous imports\n\
+    \  :list\t\t\tLists all defined variables\n\
     \  :exit\t\t\tExits elm-repl\n"

--- a/src/Read.hs
+++ b/src/Read.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Read (input) where
+module Read (input, extractDefName) where
 
 import qualified Data.Char as Char
 import qualified Data.List as List
@@ -52,6 +52,7 @@ config =
       case flag of
         "exit"  -> ok Env.Exit
         "reset" -> ok Env.Reset
+        "list"  -> ok Env.List
         "help"  -> ok (Env.Help Nothing)
         "flags" -> ok (Env.InfoFlags Nothing) <|> flags
         _       -> return $ Env.Help (Just flag)


### PR DESCRIPTION
:list allows the user to get a list of all variables they have defined.

Credits to @jwarley as well.